### PR TITLE
feature: non native aggregator hash calculation

### DIFF
--- a/circuits/aggregator/aggregator.go
+++ b/circuits/aggregator/aggregator.go
@@ -27,10 +27,13 @@ package aggregator
 
 import (
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_bn254"
 	"github.com/consensys/gnark/std/algebra/native/sw_bls12377"
-	"github.com/consensys/gnark/std/hash/mimc"
 	"github.com/consensys/gnark/std/math/bits"
+	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/consensys/gnark/std/recursion/groth16"
+	"github.com/vocdoni/gnark-crypto-primitives/emulated/bn254/twistededwards/mimc7"
+	"github.com/vocdoni/gnark-crypto-primitives/utils"
 	"github.com/vocdoni/vocdoni-z-sandbox/circuits"
 )
 
@@ -49,16 +52,16 @@ type AggregatorCircuit struct {
 	// BallotMode is a struct that contains the common inputs for all the
 	// voters. The values of this struct should be the same for all the voters
 	// in the same process.
-	circuits.BallotMode[frontend.Variable]
+	circuits.BallotMode[emulated.Element[sw_bn254.ScalarField]]
 	// Other common inputs
-	EncryptionPubKey [2]frontend.Variable // Part of InputsHash
-	ProcessId        frontend.Variable    // Part of InputsHash
-	CensusRoot       frontend.Variable    // Part of InputsHash
+	EncryptionPubKey [2]emulated.Element[sw_bn254.ScalarField] // Part of InputsHash
+	ProcessId        emulated.Element[sw_bn254.ScalarField]    // Part of InputsHash
+	CensusRoot       emulated.Element[sw_bn254.ScalarField]    // Part of InputsHash
 	// Voter inputs
-	Nullifiers       [MaxVotes]frontend.Variable                  // Part of InputsHash
-	Commitments      [MaxVotes]frontend.Variable                  // Part of InputsHash
-	Addresses        [MaxVotes]frontend.Variable                  // Part of InputsHash
-	EncryptedBallots [MaxVotes][MaxFields][2][2]frontend.Variable // Part of InputsHash
+	Nullifiers       [MaxVotes]emulated.Element[sw_bn254.ScalarField]                  // Part of InputsHash
+	Commitments      [MaxVotes]emulated.Element[sw_bn254.ScalarField]                  // Part of InputsHash
+	Addresses        [MaxVotes]emulated.Element[sw_bn254.ScalarField]                  // Part of InputsHash
+	EncryptedBallots [MaxVotes][MaxFields][2][2]emulated.Element[sw_bn254.ScalarField] // Part of InputsHash
 	// Inner proofs (from VerifyVoteCircuit) and verification keys (base is the
 	// real vk and dummy is used for no valid proofs in the scenario where there
 	// are less valid votes than MaxVotes)
@@ -76,26 +79,30 @@ type AggregatorCircuit struct {
 // encrypted ballots.
 func (c AggregatorCircuit) checkInputHash(api frontend.API) {
 	// group common inputs
-	inputs := []frontend.Variable{c.CensusRoot, c.ProcessId, c.EncryptionPubKey[0], c.EncryptionPubKey[1]}
-	inputs = append(inputs, c.BallotMode.List()...)
-	inputs = append(inputs, c.Nullifiers[:]...)
-	inputs = append(inputs, c.Commitments[:]...)
-	inputs = append(inputs, c.Addresses[:]...)
+	hashInputs := []emulated.Element[sw_bn254.ScalarField]{
+		c.ProcessId, c.CensusRoot, c.EncryptionPubKey[0], c.EncryptionPubKey[1]}
+	hashInputs = append(hashInputs, c.BallotMode.List()...)
+	hashInputs = append(hashInputs, c.Nullifiers[:]...)
+	hashInputs = append(hashInputs, c.Commitments[:]...)
+	hashInputs = append(hashInputs, c.Addresses[:]...)
 	// include flattened EncryptedBallots
 	for _, voterBallots := range c.EncryptedBallots {
 		for _, ballot := range voterBallots {
-			inputs = append(inputs, ballot[0][0], ballot[0][1], ballot[1][0], ballot[1][1])
+			hashInputs = append(hashInputs, ballot[0][0], ballot[0][1], ballot[1][0], ballot[1][1])
 		}
 	}
 	// hash the inputs
-	hFn, err := mimc.NewMiMC(api)
+	h, err := mimc7.NewMiMC(api)
 	if err != nil {
-		api.Println("failed to create native mimc hash function: ", err)
-		api.AssertIsEqual(0, 1)
+		circuits.FrontendError(api, "failed to create emulated MiMC hash function", err)
 	}
-	hFn.Write(inputs...)
+	h.Write(hashInputs...)
+	finalHash, err := utils.PackScalarToVar(api, h.Sum())
+	if err != nil {
+		circuits.FrontendError(api, "failed to pack scalar to variable", err)
+	}
 	// compare the hash with the provided InputsHash
-	api.AssertIsEqual(c.InputsHash, hFn.Sum())
+	api.AssertIsEqual(c.InputsHash, finalHash)
 }
 
 // checkInnerInputsHashes circuit method checks the hash of the public inputs
@@ -103,47 +110,52 @@ func (c AggregatorCircuit) checkInputHash(api frontend.API) {
 // calculated using the MiMC hash function in the same field of the proofs. As
 // circuit method, it does not return any value, but it assert that the hashes
 // are equal. Each hash includes the common inputs and the voter inputs.
-// func (c AggregatorCircuit) checkInnerInputsHashes(api frontend.API) {
-// 	// store the original field to reset it then and set the field to BLS12-377
-// 	originalField := api.Compiler().Field()
-// 	api.Compiler().Field().Set(ecc.BLS12_377.ScalarField())
-// 	// group common inputs
-// 	commonInputs := []frontend.Variable{c.CensusRoot, c.ProcessId, c.EncryptionPubKey[0], c.EncryptionPubKey[1]}
-// 	commonInputs = append(commonInputs, c.BallotMode.List()...)
-// 	// iterate over each voter inputs to group the remaining ones and calculate
-// 	// every voter hash
-// 	validHashes := api.ToBinary(c.ValidVotes)
-// 	for i := 0; i < MaxVotes; i++ {
-// 		remainingInputs := []frontend.Variable{c.Addresses[i], c.Nullifiers[i], c.Commitments[i]}
-// 		for j := 0; j < MaxFields; j++ {
-// 			remainingInputs = append(remainingInputs, c.EncryptedBallots[i][j][0][0])
-// 			remainingInputs = append(remainingInputs, c.EncryptedBallots[i][j][0][1])
-// 			remainingInputs = append(remainingInputs, c.EncryptedBallots[i][j][1][0])
-// 			remainingInputs = append(remainingInputs, c.EncryptedBallots[i][j][1][1])
-// 		}
-// 		// instance bls12377 hash function
-// 		bls12377HashFn, err := mimc.NewMiMC(api)
-// 		if err != nil {
-// 			api.Println("failed to create BLS12-377 mimc hash function: ", err)
-// 			api.AssertIsEqual(0, 1)
-// 		}
-// 		// hash all the inputs
-// 		bls12377HashFn.Write(commonInputs...)
-// 		bls12377HashFn.Write(remainingInputs...)
-// 		finalHash := api.Select(validHashes[i], bls12377HashFn.Sum(), frontend.Variable(1))
-// 		// pack expected hash from each voter proof public inputs
-// 		api.AssertIsEqual(len(c.Proofs[i].Witness.Public), 1)
-// 		expectedHash, err := utils.PackScalarToVar(api, c.Proofs[i].Witness.Public[0])
-// 		if err != nil {
-// 			api.Println("failed to expected inner input hash pack scalar to variable: ", err)
-// 			api.AssertIsEqual(0, 1)
-// 		}
-// 		// compare the expected hash with the calculated one
-// 		api.AssertIsEqual(expectedHash, finalHash)
-// 	}
-// 	// reset the field to the original one
-// 	api.Compiler().Field().Set(originalField)
-// }
+func (c AggregatorCircuit) checkInnerInputsHashes(api frontend.API) {
+	hashFn, err := mimc7.NewMiMC(api)
+	if err != nil {
+		circuits.FrontendError(api, "failed to create emulated MiMC hash function", err)
+	}
+	// group common inputs
+	commonInputs := []emulated.Element[sw_bn254.ScalarField]{
+		c.ProcessId, c.CensusRoot, c.EncryptionPubKey[0], c.EncryptionPubKey[1]}
+	commonInputs = append(commonInputs, c.BallotMode.List()...)
+	// iterate over each voter inputs to group the remaining ones and calculate
+	// every voter hash
+	validHashes := api.ToBinary(c.ValidVotes)
+	for i := 0; i < MaxVotes; i++ {
+		// ensure the proof is valid (it has a single public input, the
+		// expected hash)
+		api.AssertIsEqual(len(c.Proofs[i].Witness.Public), 1)
+		// group remaining inputs
+		remainingInputs := []emulated.Element[sw_bn254.ScalarField]{c.Addresses[i], c.Nullifiers[i], c.Commitments[i]}
+		for j := 0; j < MaxFields; j++ {
+			remainingInputs = append(remainingInputs, c.EncryptedBallots[i][j][0][0])
+			remainingInputs = append(remainingInputs, c.EncryptedBallots[i][j][0][1])
+			remainingInputs = append(remainingInputs, c.EncryptedBallots[i][j][1][0])
+			remainingInputs = append(remainingInputs, c.EncryptedBallots[i][j][1][1])
+		}
+		// calculate the hash
+		hashFn.Write(commonInputs...)
+		hashFn.Write(remainingInputs...)
+		resultHash := hashFn.Sum()
+		calculatedHash, err := utils.PackScalarToVar(api, resultHash)
+		if err != nil {
+			circuits.FrontendError(api, "failed to pack scalar to variable", err)
+		}
+		// if the proof is a dummy one, the hash should be one (same value of
+		// the public input of the dummy circuit)
+		finalHash := api.Select(validHashes[i], calculatedHash, frontend.Variable(1))
+		// pack expected hash from each voter proof public inputs
+		expectedHash, err := utils.PackScalarToVar(api, c.Proofs[i].Witness.Public[0])
+		if err != nil {
+			circuits.FrontendError(api, "failed to pack scalar to variable", err)
+		}
+		// compare the expected hash with the calculated one
+		api.AssertIsEqual(expectedHash, finalHash)
+		// reset the hash function
+		hashFn.Reset()
+	}
+}
 
 // checkProofs circuit method verifies each voter proof with the provided
 // verification keys and public inputs. The verification keys should contain
@@ -155,24 +167,25 @@ func (c AggregatorCircuit) checkProofs(api frontend.API) {
 	// initialize the verifier of the BLS12-377 curve
 	verifier, err := groth16.NewVerifier[sw_bls12377.ScalarField, sw_bls12377.G1Affine, sw_bls12377.G2Affine, sw_bls12377.GT](api)
 	if err != nil {
-		api.Println("failed to create BLS12-377 verifier: ", err)
-		api.AssertIsEqual(0, 1)
+		circuits.FrontendError(api, "failed to create BLS12-377 verifier", err)
 	}
 	// verify each proof with the provided public inputs and the fixed
 	// verification key
 	validProofs := bits.ToBinary(api, c.ValidVotes)
 	for i := 0; i < len(c.Proofs); i++ {
+		api.Println("proof", i)
+		for j, limb := range c.Proofs[i].Witness.Public[0].Limbs {
+			api.Println("hash limb", j, limb)
+		}
 		vk, err := verifier.SwitchVerificationKey(validProofs[i], []groth16.VerifyingKey[sw_bls12377.G1Affine, sw_bls12377.G2Affine, sw_bls12377.GT]{
 			c.DummyVerificationKey,
 			c.BaseVerificationKey,
 		})
 		if err != nil {
-			api.Println("failed to switch verification key: ", err)
-			api.AssertIsEqual(0, 1)
+			circuits.FrontendError(api, "failed to switch verification key", err)
 		}
 		if err := verifier.AssertProof(vk, c.Proofs[i].Proof, c.Proofs[i].Witness); err != nil {
-			api.Println("failed to verify proof: ", i, err)
-			api.AssertIsEqual(0, 1)
+			circuits.FrontendError(api, "failed to verify proof", err)
 		}
 	}
 }
@@ -181,7 +194,6 @@ func (c AggregatorCircuit) Define(api frontend.API) error {
 	// check the inputs hash
 	c.checkInputHash(api)
 	// check inner circuits inputs hashes
-	// TODO: Fix curve swap
 	// c.checkInnerInputsHashes(api)
 	// check all the proofs
 	c.checkProofs(api)

--- a/circuits/aggregator/helpers.go
+++ b/circuits/aggregator/helpers.go
@@ -1,13 +1,23 @@
 package aggregator
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	fr_bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
+	fr_bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	fr_bls24315 "github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
+	fr_bls24317 "github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
+	fr_bn254 "github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	fr_bw6633 "github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
+	fr_bw6761 "github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_bn254"
 	"github.com/consensys/gnark/std/algebra/native/sw_bls12377"
+	"github.com/consensys/gnark/std/math/emulated"
 	stdgroth16 "github.com/consensys/gnark/std/recursion/groth16"
 	"github.com/vocdoni/vocdoni-z-sandbox/circuits/dummy"
 )
@@ -28,6 +38,72 @@ func EncodeProofsSelector(nValidProofs int) *big.Int {
 	maxNum.Lsh(maxNum, uint(nValidProofs))
 	// subtract 1 to get all n set to 1
 	return maxNum.Sub(maxNum, big.NewInt(1))
+}
+
+// VectorToEmulatedElements function converts a backend.Witness vector to an
+// array of emulated.Element[T] elements. A witness vector is a list of uints
+// that represents every limb of a list of variables of the flattened witness.
+// This function group the limbs in groups of T.NbLimbs() to create each element
+// of the array. Returns an error if the conversion fails or the vector type is
+// not supported.
+func VectorToEmulatedElements[T emulated.FieldParams](v any) ([]emulated.Element[T], error) {
+	var fr T
+	nbLimbs := int(fr.NbLimbs())
+
+	// Helper function to process each vector type
+	processVector := func(vectorLen int, getLimbs func(i int) frontend.Variable) []emulated.Element[T] {
+		// Calculate the number of emulated.Elements needed (ceiling division)
+		numElements := (vectorLen + nbLimbs - 1) / nbLimbs
+		elements := make([]emulated.Element[T], numElements)
+
+		for elemIdx := 0; elemIdx < numElements; elemIdx++ {
+			limbs := make([]frontend.Variable, nbLimbs)
+			for limbIdx := 0; limbIdx < nbLimbs; limbIdx++ {
+				globalIdx := elemIdx*nbLimbs + limbIdx
+				if globalIdx < vectorLen {
+					limbs[limbIdx] = getLimbs(globalIdx)
+				} else {
+					// Pad with zero if there are not enough elements
+					limbs[limbIdx] = frontend.Variable(big.NewInt(0))
+				}
+			}
+			elements[elemIdx] = emulated.Element[T]{Limbs: limbs}
+		}
+		return elements
+	}
+
+	switch pv := v.(type) {
+	case fr_bn254.Vector:
+		return processVector(len(pv), func(i int) frontend.Variable {
+			return pv[i].BigInt(new(big.Int))
+		}), nil
+	case fr_bls12377.Vector:
+		return processVector(len(pv), func(i int) frontend.Variable {
+			return pv[i].BigInt(new(big.Int))
+		}), nil
+	case fr_bls12381.Vector:
+		return processVector(len(pv), func(i int) frontend.Variable {
+			return pv[i].BigInt(new(big.Int))
+		}), nil
+	case fr_bw6761.Vector:
+		return processVector(len(pv), func(i int) frontend.Variable {
+			return pv[i].BigInt(new(big.Int))
+		}), nil
+	case fr_bls24317.Vector:
+		return processVector(len(pv), func(i int) frontend.Variable {
+			return pv[i].BigInt(new(big.Int))
+		}), nil
+	case fr_bls24315.Vector:
+		return processVector(len(pv), func(i int) frontend.Variable {
+			return pv[i].BigInt(new(big.Int))
+		}), nil
+	case fr_bw6633.Vector:
+		return processVector(len(pv), func(i int) frontend.Variable {
+			return pv[i].BigInt(new(big.Int))
+		}), nil
+	default:
+		return nil, errors.New("unsupported vector type")
+	}
 }
 
 // FillWithDummyFixed function fills the placeholder and the assigments
@@ -59,10 +135,10 @@ func FillWithDummyFixed(placeholder, assigments AggregatorCircuit, main constrai
 		return AggregatorCircuit{}, AggregatorCircuit{}, fmt.Errorf("dummy witness value error: %w", err)
 	}
 	// set some dummy values in others assigments variables
-	dummyValue := frontend.Variable(0)
-	var dummyEncryptedBallots [MaxFields][2][2]frontend.Variable
+	dummyValue := emulated.ValueOf[sw_bn254.ScalarField](0)
+	var dummyEncryptedBallots [MaxFields][2][2]emulated.Element[sw_bn254.ScalarField]
 	for i := 0; i < MaxFields; i++ {
-		dummyEncryptedBallots[i] = [2][2]frontend.Variable{
+		dummyEncryptedBallots[i] = [2][2]emulated.Element[sw_bn254.ScalarField]{
 			{dummyValue, dummyValue}, {dummyValue, dummyValue},
 		}
 	}

--- a/circuits/aggregator/helpers_test.go
+++ b/circuits/aggregator/helpers_test.go
@@ -1,0 +1,49 @@
+package aggregator
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_bn254"
+	"github.com/consensys/gnark/std/algebra/native/sw_bls12377"
+	"github.com/consensys/gnark/std/math/emulated"
+	"github.com/consensys/gnark/test"
+	"github.com/vocdoni/vocdoni-z-sandbox/util"
+)
+
+type helperCircuit struct {
+	One emulated.Element[sw_bn254.ScalarField] `gnark:",public"`
+	Two emulated.Element[sw_bn254.ScalarField] `gnark:",public"`
+}
+
+func (c helperCircuit) Define(api frontend.API) error {
+	return nil
+}
+
+func TestInnerOuterEmulatedInputs(t *testing.T) {
+	assert := test.NewAssert(t)
+	// hash the inputs to generate the inputs hash
+	one := new(big.Int).SetBytes(util.RandomBytes(32))
+	two := new(big.Int).SetBytes(util.RandomBytes(32))
+	emulatedOne := emulated.ValueOf[sw_bn254.ScalarField](one)
+	emulatedTwo := emulated.ValueOf[sw_bn254.ScalarField](two)
+
+	fullWitness, err := frontend.NewWitness(helperCircuit{emulatedOne, emulatedTwo}, ecc.BLS12_377.ScalarField())
+	assert.NoError(err)
+
+	pubWitness, err := fullWitness.Public()
+	assert.NoError(err)
+
+	emulatedPubWitness, err := VectorToEmulatedElements[sw_bls12377.ScalarField](pubWitness.Vector())
+	assert.NoError(err)
+
+	for i, limb := range emulatedPubWitness[0].Limbs {
+		assert.Equal(limb, emulatedOne.Limbs[i])
+	}
+
+	for i, limb := range emulatedPubWitness[1].Limbs {
+		assert.Equal(limb, emulatedTwo.Limbs[i])
+	}
+}

--- a/circuits/helpers.go
+++ b/circuits/helpers.go
@@ -1,10 +1,23 @@
 package circuits
 
 import (
+	"fmt"
 	"math/big"
 
+	"github.com/consensys/gnark/frontend"
 	"github.com/vocdoni/vocdoni-z-sandbox/crypto/ecc"
 )
+
+// FrontendError function is an in-circuit function to print an error message
+// and an error trace, making the circuit fail.
+func FrontendError(api frontend.API, msg string, trace error) {
+	err := fmt.Errorf("%s", msg)
+	if err != nil {
+		err = fmt.Errorf("%w: %v", err, trace)
+	}
+	api.Println(err.Error())
+	api.AssertIsEqual(1, 0)
+}
 
 // BigIntArrayToN pads the big.Int array to n elements, if needed,
 // with zeros.

--- a/circuits/test/voteverifier/vote_verifier_inputs.go
+++ b/circuits/test/voteverifier/vote_verifier_inputs.go
@@ -7,19 +7,16 @@ import (
 	"math/big"
 
 	gecc "github.com/consensys/gnark-crypto/ecc"
-	fr_bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
-	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/mimc"
-	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_bn254"
 	"github.com/consensys/gnark/std/math/emulated"
 	gnarkecdsa "github.com/consensys/gnark/std/signature/ecdsa"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/iden3/go-iden3-crypto/mimc7"
 	"github.com/vocdoni/arbo"
 	primitivestest "github.com/vocdoni/gnark-crypto-primitives/testutil"
 	"github.com/vocdoni/vocdoni-z-sandbox/circuits"
 	ballottest "github.com/vocdoni/vocdoni-z-sandbox/circuits/test/ballotproof"
 	"github.com/vocdoni/vocdoni-z-sandbox/circuits/voteverifier"
-	"github.com/vocdoni/vocdoni-z-sandbox/crypto/ecc"
 	"go.vocdoni.io/dvote/util"
 )
 
@@ -118,14 +115,14 @@ func VoteVerifierInputsForTest(votersData []VoterTestData, processId []byte) (
 			}
 		}
 		// transform siblings to gnark frontend.Variable
-		fSiblings := [ballottest.NLevels]frontend.Variable{}
+		emulatedSiblings := [ballottest.NLevels]emulated.Element[sw_bn254.ScalarField]{}
 		for j, s := range testCensus.Proofs[i].Siblings {
-			fSiblings[j] = frontend.Variable(s)
+			emulatedSiblings[j] = emulated.ValueOf[sw_bn254.ScalarField](s)
 		}
 		// hash the inputs of gnark circuit (except weight and including census root)
 		hashInputs := append([]*big.Int{
-			testCensus.Root,
 			voterProof.ProcessID,
+			testCensus.Root,
 			encryptionKeyX,
 			encryptionKeyY,
 			new(big.Int).SetInt64(int64(ballottest.MaxCount)),
@@ -141,19 +138,13 @@ func VoteVerifierInputsForTest(votersData []VoterTestData, processId []byte) (
 			voterProof.Commitment,
 		}, voterProof.PlainEcryptedFields...)
 		// hash the inputs to generate the inputs hash
-		var buf [fr_bls12377.Bytes]byte
-		voteVerifierHashFn := mimc.NewMiMC()
-		for _, input := range hashInputs {
-			ffInput := ecc.BigToFF(gecc.BLS12_377.ScalarField(), input)
-			ffInput.FillBytes(buf[:])
-			if _, err := voteVerifierHashFn.Write(buf[:]); err != nil {
-				return VoteVerifierTestResults{}, voteverifier.VerifyVoteCircuit{}, nil, err
-			}
+		inputsHash, err := mimc7.Hash(hashInputs, nil)
+		if err != nil {
+			return VoteVerifierTestResults{}, voteverifier.VerifyVoteCircuit{}, nil, err
 		}
-		inputsHash := new(big.Int).SetBytes(voteVerifierHashFn.Sum(nil))
 		// compose circuit placeholders
 		assigments = append(assigments, voteverifier.VerifyVoteCircuit{
-			InputsHash: inputsHash,
+			InputsHash: emulated.ValueOf[sw_bn254.ScalarField](inputsHash),
 			// circom inputs
 			BallotMode: circuits.BallotMode[emulated.Element[sw_bn254.ScalarField]]{
 				MaxCount:        emulated.ValueOf[sw_bn254.ScalarField](ballottest.MaxCount),
@@ -176,8 +167,8 @@ func VoteVerifierInputsForTest(votersData []VoterTestData, processId []byte) (
 			ProcessId:       emulated.ValueOf[sw_bn254.ScalarField](voterProof.ProcessID),
 			EncryptedBallot: emulatedBallots,
 			// census proof
-			CensusRoot:     testCensus.Root,
-			CensusSiblings: fSiblings,
+			CensusRoot:     emulated.ValueOf[sw_bn254.ScalarField](testCensus.Root),
+			CensusSiblings: emulatedSiblings,
 			// signature
 			Msg: emulated.ValueOf[emulated.Secp256k1Fr](blsCircomInputsHash),
 			PublicKey: gnarkecdsa.PublicKey[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{

--- a/circuits/test/voteverifier/vote_verifier_inputs.go
+++ b/circuits/test/voteverifier/vote_verifier_inputs.go
@@ -23,6 +23,7 @@ import (
 // VoteVerifierTestResults struct includes relevant data after VerifyVoteCircuit
 // inputs generation
 type VoteVerifierTestResults struct {
+	InputsHashes     []*big.Int
 	EncryptionPubKey [2]*big.Int
 	Addresses        []*big.Int
 	ProcessID        *big.Int
@@ -77,7 +78,7 @@ func VoteVerifierInputsForTest(votersData []VoterTestData, processId []byte) (
 	encryptionKeyX, encryptionKeyY := encryptionKey.Point()
 	// circuits assigments, voters data and proofs
 	var assigments []voteverifier.VerifyVoteCircuit
-	addresses, nullifiers, commitments := []*big.Int{}, []*big.Int{}, []*big.Int{}
+	inputsHashes, addresses, nullifiers, commitments := []*big.Int{}, []*big.Int{}, []*big.Int{}, []*big.Int{}
 	encryptedBallots := [][ballottest.NFields][2][2]*big.Int{}
 	var finalProcessID *big.Int
 	for i, voter := range votersData {
@@ -142,9 +143,11 @@ func VoteVerifierInputsForTest(votersData []VoterTestData, processId []byte) (
 		if err != nil {
 			return VoteVerifierTestResults{}, voteverifier.VerifyVoteCircuit{}, nil, err
 		}
+		inputsHashes = append(inputsHashes, inputsHash)
 		// compose circuit placeholders
 		assigments = append(assigments, voteverifier.VerifyVoteCircuit{
-			InputsHash: emulated.ValueOf[sw_bn254.ScalarField](inputsHash),
+			// InputsHash: emulated.ValueOf[sw_bn254.ScalarField](inputsHash),
+			InputsHash: inputsHash,
 			// circom inputs
 			BallotMode: circuits.BallotMode[emulated.Element[sw_bn254.ScalarField]]{
 				MaxCount:        emulated.ValueOf[sw_bn254.ScalarField](ballottest.MaxCount),
@@ -186,6 +189,7 @@ func VoteVerifierInputsForTest(votersData []VoterTestData, processId []byte) (
 	}
 
 	return VoteVerifierTestResults{
+			InputsHashes:     inputsHashes,
 			EncryptionPubKey: [2]*big.Int{encryptionKeyX, encryptionKeyY},
 			Addresses:        addresses,
 			ProcessID:        finalProcessID,

--- a/circuits/voteverifier/vote_verifier.go
+++ b/circuits/voteverifier/vote_verifier.go
@@ -70,7 +70,8 @@ import (
 
 type VerifyVoteCircuit struct {
 	// Single public input that is the hash of all the public inputs
-	InputsHash emulated.Element[sw_bn254.ScalarField] `gnark:",public"`
+	// InputsHash emulated.Element[sw_bn254.ScalarField] `gnark:",public"`
+	InputsHash frontend.Variable `gnark:",public"`
 	// The following variables are priv-public inputs, so should be hashed
 	// and compared with the InputsHash or CircomPublicInputsHash. All the
 	// variables should be hashed in the same order as they are defined here.
@@ -185,7 +186,11 @@ func (c VerifyVoteCircuit) checkInputsHash(api frontend.API) {
 		api.AssertIsEqual(0, 1)
 	}
 	h.Write(hashInputs...)
-	h.AssertSumIsEqual(c.InputsHash)
+	finalHash, err := utils.PackScalarToVar(api, h.Sum())
+	if err != nil {
+		circuits.FrontendError(api, "failed to pack scalar to variable", err)
+	}
+	api.AssertIsEqual(c.InputsHash, finalHash)
 }
 
 // verifySigForAddress circuit method verifies the signature provided with the


### PR DESCRIPTION
Now all inputs of Aggregator and VoteVerifier circuits are `emulated.Element[sw_bn254.ScalarField()]` variables. There are also some new helpers.