### PR TITLE
Faster integration tests

### DIFF
--- a/circuits/test/aggregator/aggregator_inputs.go
+++ b/circuits/test/aggregator/aggregator_inputs.go
@@ -368,18 +368,21 @@ func AggregatorInputsWithDummyProof(processId []byte, nValidVoters int, persist 
 			Address: address,
 		})
 	}
+	fmt.Println("start VoteVerifierInputsWithoutProof") // debug
 
 	// generate vote verifier inputs
 	vvInputs, _, _, err := voteverifiertest.VoteVerifierInputsWithoutProof(vvData, processId)
 	if err != nil {
 		return AggregatorTestResults{}, aggregator.AggregatorCircuit{}, aggregator.AggregatorCircuit{}, fmt.Errorf("voteverifier inputs: %w", err)
 	}
+	fmt.Println("end VoteVerifierInputsWithoutProof") // debug
 
 	// compile vote verifier circuit
 	dummyCCS, err := frontend.Compile(circuits.VoteVerifierCurve.ScalarField(), r1cs.NewBuilder, dummy.PlaceholderWithConstraints(0))
 	if err != nil {
 		return AggregatorTestResults{}, aggregator.AggregatorCircuit{}, aggregator.AggregatorCircuit{}, fmt.Errorf("voteverifier compile: %w", err)
 	}
+	fmt.Println("end Compile") // debug
 
 	// compute public inputs hash
 	commonInputs := []*big.Int{vvInputs.ProcessID, vvInputs.CensusRoot}
@@ -412,6 +415,7 @@ func AggregatorInputsWithDummyProof(processId []byte, nValidVoters int, persist 
 	if err != nil {
 		return AggregatorTestResults{}, aggregator.AggregatorCircuit{}, aggregator.AggregatorCircuit{}, fmt.Errorf("inputsHash final hash: %w", err)
 	}
+	fmt.Println("end Hashes") // debug
 
 	// init final assignments stuff
 	finalAssigments := aggregator.AggregatorCircuit{

--- a/circuits/test/aggregator/aggregator_test.go
+++ b/circuits/test/aggregator/aggregator_test.go
@@ -1,6 +1,7 @@
 package aggregatortest
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -45,6 +46,7 @@ func TestAggregatorCircuitWithDummy(t *testing.T) {
 	// inputs generation
 	now := time.Now()
 	processId := util.RandomBytes(20)
+	fmt.Println("start") // debug
 	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: "15:04:05"}).With().Timestamp().Logger())
 
 	_, placeholder, assignments, err := AggregatorInputsWithDummyProof(processId, 3, false)

--- a/circuits/test/statetransition/statetransition_test.go
+++ b/circuits/test/statetransition/statetransition_test.go
@@ -1,6 +1,7 @@
 package statetransitiontest
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -20,6 +21,7 @@ func TestStateTransitionCircuit(t *testing.T) {
 	// inputs generation
 	now := time.Now()
 	processId := util.RandomBytes(20)
+	fmt.Println("start") // debug
 	_, placeholder, assignments, err := StateTransitionInputsForTest(processId, 3)
 	c.Assert(err, qt.IsNil)
 	c.Logf("inputs generation took %s", time.Since(now).String())

--- a/circuits/test/voteverifier/vote_verifier_inputs.go
+++ b/circuits/test/voteverifier/vote_verifier_inputs.go
@@ -214,6 +214,7 @@ func VoteVerifierInputsWithoutProof(votersData []VoterTestData, processId []byte
 	ballots := []elgamal.Ballot{}
 	var finalProcessID *big.Int
 	for _, voter := range votersData {
+		fmt.Println("VoterWithoutProof") // debug
 		voterProof, err := ballottest.VoterWithoutProof(voter.Address.Bytes(), processId, ek)
 		if err != nil {
 			return VoteVerifierTestResults{}, voteverifier.VerifyVoteCircuit{}, nil, fmt.Errorf("ballotproof inputs: %w", err)


### PR DESCRIPTION
- **circuits/test: add methods to generate inputs without proving**

this enables to quickly generate inputs for statetransition integration test
