### PR TITLE
feature: aggregator witnesses check

### DIFF
--- a/circuits/aggregator/aggregator.go
+++ b/circuits/aggregator/aggregator.go
@@ -1,45 +1,83 @@
 // aggregator package contains the Gnark circuit defiinition that aggregates
 // some votes and proves the validity of the aggregation. The circuit checks
 // every single verification proof generating a single proof for the whole
-// aggregation. Every voter proof should use the same values for the following
-// inputs:
-//   - MaxCount
-//   - ForceUniqueness
-//   - MaxValue
-//   - MinValue
-//   - MaxTotalCost
-//   - MinTotalCost
-//   - CostExp
-//   - CostFromWeight
-//   - EncryptionPubKey
-//   - ProcessId
-//   - CensusRoot
-//
-// All these values are common for the same process.
-//
-// The circuit also checks the other inputs that are unique for each voter:
-//   - Nullifier
-//   - Commitment
-//   - Address
-//   - Ballot
-//   - VerifyProof (generated with the VerifyVoteCircuit)
+// aggregation. It also checks that the number of valid votes and that the
+// hash of the witnesses is the expected.
 package aggregator
 
 import (
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_bn254"
 	"github.com/consensys/gnark/std/algebra/native/sw_bls12377"
+	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/consensys/gnark/std/recursion/groth16"
+	"github.com/vocdoni/gnark-crypto-primitives/hash/bn254/mimc7"
 	"github.com/vocdoni/vocdoni-z-sandbox/circuits"
 )
 
 type AggregatorCircuit struct {
-	ValidProofs     frontend.Variable `gnark:",public"`
+	ValidProofs     frontend.Variable                      `gnark:",public"`
+	WitnessesHash   emulated.Element[sw_bn254.ScalarField] `gnark:",public"`
 	Proofs          [circuits.VotesPerBatch]groth16.Proof[sw_bls12377.G1Affine, sw_bls12377.G2Affine]
 	Witnesses       [circuits.VotesPerBatch]groth16.Witness[sw_bls12377.ScalarField]
 	VerificationKey groth16.VerifyingKey[sw_bls12377.G1Affine, sw_bls12377.G2Affine, sw_bls12377.GT] `gnark:"-"`
 }
 
-func (c AggregatorCircuit) Define(api frontend.API) error {
+// checkWitnessesHash checks that the hash of the witnesses is the expected
+// value. The hash of the witnesses is calculated using the MiMC7 hash function
+// over emulated.Element[sw_bn254.ScalarField] inputs. The expected number of
+// inputs is the number of votes times 2, where each vote has two public inputs
+// (valid vote indicator and inputs hash).
+func (c AggregatorCircuit) checkWitnessesHash(api frontend.API) {
+	// initialize the hash function
+	hFn, err := mimc7.NewMiMC(api)
+	if err != nil {
+		circuits.FrontendError(api, "failed to create MiMC hash function", err)
+		return
+	}
+	// To build the hash of the witnesses, we expect to have two public inputs
+	// per proof:
+	//  - the first one should be an emulated frontend.Variable wich indicates
+	//    if the proof is valid or not.
+	//    (Original: 1 or 0, Emulated: [1 0 0 0] or [0 0 0 0])
+	//  - the second one should be the hash of the inputs of the vote verifier
+	//    circuit as emulated emulated.Element[sw_bn254.ScalarField]. As
+	//    emulated emulated.Element, each original limb of the hash should be
+	//    represented as a slice of 4 elements, the first limb contains the
+	//    original value and the rest are zeros.
+	//    (Original: [1 2 3 4], Emulated: [[1 0 0 0] [2 0 0 0] [3 0 0 0] [4 0 0 0])
+	// The hash function expect emulated.Element[sw_bn254.ScalarField] as inputs
+	// so we need to convert the public inputs to the expected type, keeping the
+	// the first public input as is and reconstructing the second one grouping
+	// each first limb in a slice of 4 elements.
+	for _, w := range c.Witnesses {
+		// check that the number of public inputs is the expected
+		api.AssertIsEqual(len(w.Public), 5)
+		// include the valid vote indicator in the hash
+		hFn.Write(emulated.Element[sw_bn254.ScalarField]{Limbs: w.Public[0].Limbs})
+		// reconstruct the hash of the inputs of the vote verifier circuit
+		inputsHashLimbs := emulated.Element[sw_bn254.ScalarField]{Limbs: []frontend.Variable{}}
+		for _, pub := range w.Public[1:] {
+			inputsHashLimbs.Limbs = append(inputsHashLimbs.Limbs, pub.Limbs[0])
+		}
+		// include the inputs hash in the hash
+		hFn.Write(inputsHashLimbs)
+	}
+	// check that the hash of the witnesses is the expected
+	hFn.AssertSumIsEqual(c.WitnessesHash)
+}
+
+// checkProofs checks that the proofs are valid and that the number of valid
+// proofs is the expected. The verification of the proofs is done using the
+// provided verification key and the public inputs of the witnesses. The number
+// of valid proofs is calculated by counting the number of valid votes. A vote
+// is considered valid if the first limb of the first public input in the
+// witness is 1, otherwise it is considered invalid. The number of valid votes
+// is calculated by adding the result of the AND operation between the last
+// valid vote and the current vote. The number of valid votes is the expected
+// number of valid proofs. Only the first n proofs can be valid, so the
+// counting stops after the first invalid proof.
+func (c AggregatorCircuit) checkProofs(api frontend.API) {
 	// initialize the verifier of the BLS12-377 curve
 	verifier, err := groth16.NewVerifier[sw_bls12377.ScalarField, sw_bls12377.G1Affine, sw_bls12377.G2Affine, sw_bls12377.GT](api)
 	if err != nil {
@@ -69,5 +107,12 @@ func (c AggregatorCircuit) Define(api frontend.API) error {
 	}
 	// check that the number of valid votes is the expected
 	api.AssertIsEqual(c.ValidProofs, validVotes)
+}
+
+func (c AggregatorCircuit) Define(api frontend.API) error {
+	// check the hash of the witnesses
+	c.checkWitnessesHash(api)
+	// check the proofs
+	c.checkProofs(api)
 	return nil
 }

--- a/circuits/test/aggregator/aggregator_inputs.go
+++ b/circuits/test/aggregator/aggregator_inputs.go
@@ -7,11 +7,8 @@ import (
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
-	"github.com/consensys/gnark/std/algebra/emulated/sw_bn254"
 	"github.com/consensys/gnark/std/algebra/native/sw_bls12377"
-	"github.com/consensys/gnark/std/math/emulated"
 	stdgroth16 "github.com/consensys/gnark/std/recursion/groth16"
-	"github.com/iden3/go-iden3-crypto/mimc7"
 	"github.com/vocdoni/arbo"
 	"github.com/vocdoni/vocdoni-z-sandbox/circuits"
 	"github.com/vocdoni/vocdoni-z-sandbox/circuits/aggregator"
@@ -91,34 +88,11 @@ func AggregatorInputsForTest(processId []byte, nValidVotes int) (
 			return nil, nil, nil, err
 		}
 	}
-	witnessesHashInputs := []*big.Int{}
-	for i := range circuits.VotesPerBatch {
-		if i < nValidVotes {
-			// append 1 to the inputs to hash to include the valid vote indicator
-			// before the inputs hash
-			witnessesHashInputs = append(witnessesHashInputs, big.NewInt(1), vvInputs.InputsHashes[i])
-		} else {
-			// append 0 to the inputs to hash to include the valid vote indicator
-			// before the dummy input hash (1)
-			witnessesHashInputs = append(witnessesHashInputs, big.NewInt(0), big.NewInt(1))
-		}
-	}
-	// the expected number of hash inputs is the number of votes plus the
-	// number of public inputs of the vote verifier circuit (valid vote
-	// indicator and inputs hash)
-	if len(witnessesHashInputs) != circuits.VotesPerBatch*2 {
-		return nil, nil, nil, fmt.Errorf("unexpected number of hash inputs: %d", len(witnessesHashInputs))
-	}
-	witnessesHash, err := mimc7.Hash(witnessesHashInputs, nil)
-	if err != nil {
-		return nil, nil, nil, err
-	}
 	// init final assignments stuff
 	finalAssigments := &aggregator.AggregatorCircuit{
-		ValidProofs:   nValidVotes,
-		WitnessesHash: emulated.ValueOf[sw_bn254.ScalarField](witnessesHash),
-		Proofs:        proofs,
-		Witnesses:     witnesses,
+		ValidProofs: nValidVotes,
+		Proofs:      proofs,
+		Witnesses:   witnesses,
 	}
 	// fill assignments with dummy values
 	if err := finalAssigments.FillWithDummy(vvCCS, vvPk, ballottest.TestCircomVerificationKey, nValidVotes); err != nil {


### PR DESCRIPTION
This PR contains two new versions of the Aggregator circuit (3):
* From both, the VoterVerifier proofs witnesses calculation has been removed. It has been replaced by new circuit inputs with these witnesses (the bit that indicates if each proof is valid or dummy vote, and the hash of its public inputs).
* The first one receives the number of valid votes and the hash of the current public inputs (the witnesses list). -> [≈800k constrains]
* The second one receives the witnesses list as public input, with the number of valid votes. -> [≈300k constrains]